### PR TITLE
Remove copy sample database step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,6 @@ jobs:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
-      - run:
-          name: copy sample database
-          command: |
-            cp config/database.yml.sample config/database.yml
-      - run: bundle exec rake db:create
-      - run: bundle exec rake db:schema:load
-
       - restore_cache:
           keys:
             - v1-{{ .Branch }}


### PR DESCRIPTION
## Description
- Removes the copy sample database step from `from push_to_docker_hub` because it was causing the docker image build job to fail